### PR TITLE
html: replace WebSocket content updates with reload signals

### DIFF
--- a/template.html
+++ b/template.html
@@ -331,19 +331,9 @@
             socket.onmessage = function(event) {
                 try {
                     const message = JSON.parse(event.data);
-                    if (message.type === 'ContentUpdate') {
-                        // Parse the received HTML to extract just the content
-                        const parser = new DOMParser();
-                        const doc = parser.parseFromString(message.html, 'text/html');
-                        const newContent = doc.getElementById('content');
-
-                        if (newContent) {
-                            const currentContent = document.getElementById('content');
-                            if (currentContent) {
-                                currentContent.innerHTML = newContent.innerHTML;
-                                console.log('Content updated via WebSocket');
-                            }
-                        }
+                    if (message.type === 'Reload') {
+                        console.log('Reloading page via WebSocket');
+                        window.location.reload();
                     }
                 } catch (error) {
                     console.error('Error parsing WebSocket message:', error);


### PR DESCRIPTION
Switch from sending full HTML content over WebSocket to lightweight reload signals that trigger browser page refreshes. This reduces network overhead from 15KB+ payloads to ~20 byte messages while simplifying client-side logic.

Browser reloads naturally handle caching, scroll position, and theme persistence through localStorage. This foundational change enables future client-side Mermaid support where page reloads are simpler than coordinating diagram re-rendering via WebSocket handlers.