### PR TITLE
fix: change default hostname to 127.0.0.1 to prevent port conflicts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ struct Args {
     file: PathBuf,
 
     /// Hostname (domain or IP address) to listen on
-    #[arg(short = 'H', long, default_value = "localhost")]
+    #[arg(short = 'H', long, default_value = "127.0.0.1")]
     hostname: String,
 
     /// Port to serve on


### PR DESCRIPTION
localhost resolves to both IPv4 and IPv6 addresses, allowing multiple instances to bind to the same port on different protocols. This caused the second instance to run without error but be unreachable.

Fixes: https://github.com/jfernandez/mdserve/issues/19