### PR TITLE
build: downgrade to edition 2021 and set MSRV to 1.82.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "mdserve"
 version = "0.4.1"
 authors = ["Jose Fernandez <me@jrfernandez.com>"]
-edition = "2024"
+edition = "2021"
+rust-version = "1.82.0"
 license = "MIT"
 description = "Fast markdown preview server with live reload and theme support"
 repository = "https://github.com/jfernandez/mdserve"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use axum::{
-    Router,
     extract::{
-        Path as AxumPath, State, WebSocketUpgrade,
         ws::{Message, WebSocket},
+        Path as AxumPath, State, WebSocketUpgrade,
     },
-    http::{HeaderMap, StatusCode, header},
+    http::{header, HeaderMap, StatusCode},
     response::{Html, IntoResponse},
     routing::get,
+    Router,
 };
 use futures_util::{SinkExt, StreamExt};
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
@@ -21,7 +21,7 @@ use std::{
 };
 use tokio::{
     net::TcpListener,
-    sync::{Mutex, broadcast, mpsc},
+    sync::{broadcast, mpsc, Mutex},
 };
 use tower_http::cors::CorsLayer;
 
@@ -417,10 +417,10 @@ async fn handle_websocket(socket: WebSocket, state: SharedMarkdownState) {
     let send_task = tokio::spawn(async move {
         // Listen for file changes
         while let Ok(reload_msg) = change_rx.recv().await {
-            if let Ok(json) = serde_json::to_string(&reload_msg)
-                && sender.send(Message::Text(json)).await.is_err()
-            {
-                break;
+            if let Ok(json) = serde_json::to_string(&reload_msg) {
+                if sender.send(Message::Text(json)).await.is_err() {
+                    break;
+                }
             }
         }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 // Minimal lib.rs to support integration tests
 pub mod app;
-pub use app::{ServerMessage, new_router, serve_markdown};
+pub use app::{new_router, serve_markdown, ServerMessage};

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use axum_test::TestServer;
-use mdserve::{ServerMessage, new_router};
+use mdserve::{new_router, ServerMessage};
 use std::fs;
 use tempfile::NamedTempFile;
 


### PR DESCRIPTION
## Summary

This PR fixes the compilation error on stable Rust by replacing unstable `if-let-chain` syntax with nested `if` statements.

## Problem

The current code uses an unstable Rust feature (if-let-chains, RFC #53667) that requires nightly Rust:

```rust
if let Ok(json) = serde_json::to_string(&reload_msg)
    && sender.send(Message::Text(json)).await.is_err()
{
    break;
}
```

This causes a compilation error on stable Rust:
```
error[E0658]: `let` expressions in this position are unstable
```

## Solution

Refactor to use stable Rust syntax with nested if statements:

```rust
if let Ok(json) = serde_json::to_string(&reload_msg) {
    if sender.send(Message::Text(json)).await.is_err() {
        break;
    }
}
```

This maintains identical functionality while being compatible with stable Rust.

## Testing

- Built and compiled successfully on stable Rust toolchain
- The logic flow remains exactly the same
- No functional changes to the WebSocket handling behavior

Fixes #28