### PR TITLE
feat: add directory mode for serving multiple markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ mdserve README.md -p 8080
 Once running, the server provides (default: [http://localhost:3000](http://localhost:3000)):
 
 - **[`/`](http://localhost:3000/)** - Rendered HTML with live reload via WebSocket
-- **[`/raw`](http://localhost:3000/raw)** - Raw markdown content (useful for debugging)
 - **[`/ws`](http://localhost:3000/ws)** - WebSocket endpoint for real-time updates
 
 ## Theme System

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,149 @@
+# mdserve Architecture
+
+## Overview
+
+mdserve is a simple HTTP server for markdown preview with live reload. It supports both single-file and directory modes with a unified codebase.
+
+**Core principle**: Always work with a base directory and a list of tracked files (1 or more).
+
+```mermaid
+graph LR
+    A[File System] -->|notify events| B[File Watcher]
+    B -->|update state| C[MarkdownState]
+    B -->|broadcast| D[WebSocket]
+    E[HTTP Request] -->|lookup| C
+    C -->|render| F[Template]
+    F -->|HTML| G[Browser]
+    D -->|reload signal| G
+```
+
+## Modes
+
+### Single-File Mode
+```bash
+mdserve README.md
+```
+- Watches parent directory
+- Tracks single file
+- No navigation sidebar
+
+### Directory Mode
+```bash
+mdserve ./docs/
+```
+- Watches specified directory
+- Tracks all `.md` and `.markdown` files
+- Shows navigation sidebar
+
+## Architecture
+
+### State Management
+
+Central state stores:
+- Base directory path
+- HashMap of tracked files (filename → metadata + pre-rendered HTML)
+- Directory mode flag (determines UI)
+- WebSocket broadcast channel
+
+```mermaid
+classDiagram
+    class MarkdownState {
+        +PathBuf base_dir
+        +HashMap~String,TrackedFile~ tracked_files
+        +bool is_directory_mode
+        +Sender~ServerMessage~ change_tx
+    }
+
+    class TrackedFile {
+        +PathBuf path
+        +SystemTime last_modified
+        +String html
+    }
+
+    MarkdownState "1" --> "*" TrackedFile : contains
+```
+
+Mode is determined by user intent, not file count:
+- `mdserve /docs/` with 1 file shows sidebar
+- `mdserve single.md` never shows sidebar
+
+**Example states:**
+
+Single-file mode:
+```
+base_dir = /path/to/docs/
+tracked_files = {
+  "README.md": TrackedFile { ... }
+}
+is_directory_mode = false
+```
+
+Directory mode:
+```
+base_dir = /path/to/docs/
+tracked_files = {
+  "api.md": TrackedFile { ... },
+  "guide.md": TrackedFile { ... },
+  "README.md": TrackedFile { ... }
+}
+is_directory_mode = true
+```
+
+### Live Reload
+
+Uses [notify](https://github.com/notify-rs/notify) crate to watch base directory (non-recursive):
+- Create/modify: Refresh file, add if new (directory mode only)
+- Delete: Remove from tracking
+- Rename: Remove old, add new
+- All changes trigger WebSocket reload broadcast
+
+File changes flow:
+1. File system event detected by `notify`
+2. Markdown re-rendered to HTML
+3. State updated (refresh/add/remove tracked file)
+4. `ServerMessage::Reload` broadcast via WebSocket channel
+5. All connected clients receive reload message
+6. Clients execute `window.location.reload()`
+
+### Routing
+
+Single unified router handles both modes:
+- `GET /` → First file alphabetically
+- `GET /:filename.md` → Specific markdown file
+- `GET /:filename.<ext>` → Images from base directory
+- `GET /ws` → WebSocket connection
+- `GET /mermaid.min.js` → Bundled Mermaid library
+
+The `:filename` pattern rejects paths with `/`, preventing directory traversal.
+
+### Rendering
+
+Uses [MiniJinja](https://github.com/mitsuhiko/minijinja) (Jinja2 template syntax) with templates embedded at compile time via [minijinja_embed](https://github.com/mitsuhiko/minijinja/tree/main/minijinja-embed).
+
+Conditional template rendering:
+- Directory mode: Includes navigation sidebar with active file highlighting
+- Single-file mode: Content only
+- Both use same pre-rendered HTML from state
+
+Template variables:
+- `content`: Pre-rendered markdown HTML
+- `mermaid_enabled`: Boolean flag, conditionally includes Mermaid.js when diagrams detected
+- `show_navigation`: Controls sidebar visibility
+- `files`: List of tracked files (directory mode)
+- `current_file`: Active file name (directory mode)
+
+## Design Decisions
+
+**Unified architecture**: Single code path handles both single-file and directory modes. Mode determined by user intent, not file count.
+
+**Pre-rendered caching**: All tracked files rendered to HTML in memory on startup and file change. Serving always from memory, never from disk.
+
+**Non-recursive watching**: Only immediate directory, no subdirectories. Simplifies security and state management.
+
+**Server-side logic**: Most logic lives server-side (markdown rendering, file tracking, navigation, active file highlighting, live reload triggering). Client-side JavaScript minimal (theme management, reload execution).
+
+## Constraints
+
+- Non-recursive (flat directories only)
+- Alphabetical file ordering only
+- All files pre-rendered in memory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 // Minimal lib.rs to support integration tests
 pub mod app;
-pub use app::{new_router, serve_markdown, ServerMessage};
+pub use app::{new_router, scan_markdown_files, serve_markdown, ServerMessage};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,16 @@
-mod app;
-
 use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 
-use app::serve_markdown;
+use mdserve::{scan_markdown_files, serve_markdown};
 
 #[derive(Parser)]
 #[command(name = "mdserve")]
 #[command(about = "A simple HTTP server for markdown preview")]
 #[command(version)]
 struct Args {
-    /// Path to the markdown file to serve
-    file: PathBuf,
+    /// Path to markdown file or directory to serve
+    path: PathBuf,
 
     /// Hostname (domain or IP address) to listen on
     #[arg(short = 'H', long, default_value = "127.0.0.1")]
@@ -26,11 +24,36 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
+    let absolute_path = args.path.canonicalize().unwrap_or(args.path);
 
-    // Canonicalize the path once for consistent absolute path display
-    let absolute_path = args.file.canonicalize().unwrap_or(args.file);
+    let (base_dir, tracked_files, is_directory_mode) = if absolute_path.is_file() {
+        // Single-file mode: derive parent directory
+        let base_dir = absolute_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .to_path_buf();
+        let tracked_files = vec![absolute_path];
+        (base_dir, tracked_files, false)
+    } else if absolute_path.is_dir() {
+        // Directory mode: scan directory for markdown files
+        let tracked_files = scan_markdown_files(&absolute_path)?;
+        if tracked_files.is_empty() {
+            anyhow::bail!("No markdown files found in directory");
+        }
+        (absolute_path, tracked_files, true)
+    } else {
+        anyhow::bail!("Path must be a file or directory");
+    };
 
-    serve_markdown(absolute_path, args.hostname, args.port).await?;
+    // Single unified serve function
+    serve_markdown(
+        base_dir,
+        tracked_files,
+        is_directory_mode,
+        args.hostname,
+        args.port,
+    )
+    .await?;
 
     Ok(())
 }

--- a/templates/main.html
+++ b/templates/main.html
@@ -5,17 +5,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Markdown Preview</title>
 
-    <!-- Critical: Apply theme before first paint to prevent flash -->
+    <!-- Critical: Apply theme and sidebar state before first paint to prevent flash -->
     <script>
         (function() {
-            // Get saved theme or use default
+            // Apply theme immediately
             const theme = localStorage.getItem('theme') || 'catppuccin-mocha';
-
-            // Apply immediately to <html>
             document.documentElement.setAttribute('data-theme', theme);
-
-            // Mark theme as initialized
             document.documentElement.classList.add('theme-initialized');
+
+            // Apply sidebar state to both html and body elements
+            // This works because body inherits the collapsed state via CSS selectors
+            const isSidebarCollapsed = localStorage.getItem('sidebar-collapsed') === 'true';
+            if (isSidebarCollapsed) {
+                // Set on html first for early rendering
+                document.documentElement.classList.add('sidebar-collapsed');
+
+                // Transfer to body when available
+                if (document.body) {
+                    document.body.classList.add('sidebar-collapsed');
+                } else {
+                    document.addEventListener('DOMContentLoaded', function() {
+                        document.body.classList.add('sidebar-collapsed');
+                    });
+                }
+            }
         })();
     </script>
 
@@ -29,6 +42,12 @@
             opacity: 1;
             transition: opacity 0.1s ease-in;
         }
+
+        /* Universal box-sizing */
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
+
         :root {
             --bg-color: #fff;
             --text-color: #333;
@@ -38,6 +57,11 @@
             --blockquote-color: #6a737d;
             --link-color: #0366d6;
             --table-header-bg: #f6f8fa;
+            --sidebar-width: 250px;
+            --sidebar-collapsed-width: 48px;
+            --content-max-width: 900px;
+            --transition-speed: 0.3s;
+            --transition-timing: ease;
         }
 
         [data-theme="dark"] {
@@ -84,19 +108,164 @@
             --table-header-bg: #313244;
         }
 
+        /* Common body styles */
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
             line-height: 1.6;
             color: var(--text-color);
-            max-width: 900px;
-            margin: 0 auto;
-            padding: 20px;
             background-color: var(--bg-color);
-            transition: background-color 0.3s ease, color 0.3s ease;
+            transition: background-color var(--transition-speed) var(--transition-timing),
+                        color var(--transition-speed) var(--transition-timing);
         }
 
+        {% if show_navigation %}
+        /* ============================================
+           Multi-file Navigation Layout
+           ============================================ */
+
+        html, body {
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            display: flex;
+            max-width: none;
+            min-height: 100vh;
+            overflow-x: hidden; /* Prevent horizontal scroll during transitions */
+        }
+
+        /* Sidebar */
+        .sidebar {
+            width: var(--sidebar-width);
+            min-width: var(--sidebar-width);
+            background: var(--code-bg);
+            border-right: 1px solid var(--border-color);
+            padding: 0;
+            height: 100vh;
+            position: fixed;
+            left: 0;
+            top: 0;
+            overflow-y: auto;
+            transition: width var(--transition-speed) var(--transition-timing),
+                        min-width var(--transition-speed) var(--transition-timing),
+                        background var(--transition-speed) var(--transition-timing);
+        }
+
+        body.sidebar-collapsed .sidebar {
+            width: var(--sidebar-collapsed-width);
+            min-width: var(--sidebar-collapsed-width);
+            overflow: hidden;
+            background: var(--bg-color);
+        }
+
+        .sidebar-header {
+            height: 68px; /* Space for toggle button */
+        }
+
+        .sidebar-content {
+            padding: 0 20px 20px 20px;
+            opacity: 1;
+            transition: opacity 0.2s var(--transition-timing);
+        }
+
+        body.sidebar-collapsed .sidebar-content {
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        /* File Navigation List */
+        .file-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .file-list li {
+            margin-bottom: 4px;
+        }
+
+        .file-list a {
+            display: block;
+            padding: 8px 12px;
+            color: var(--text-color);
+            text-decoration: none;
+            border-radius: 6px;
+            transition: background 0.2s var(--transition-timing);
+            font-size: 14px;
+        }
+
+        .file-list a:hover,
+        .file-list a:focus-visible {
+            background: var(--border-color-light);
+            outline: none;
+        }
+
+        .file-list a.active {
+            background: var(--border-color-light);
+            color: var(--text-color);
+            font-weight: 600;
+        }
+
+        /* Main Content Area */
+        #content {
+            margin-left: var(--sidebar-width);
+            width: var(--content-max-width);
+            max-width: calc(100% - var(--sidebar-width));
+            padding: 20px;
+            min-height: 100vh;
+            transition: margin-left var(--transition-speed) var(--transition-timing),
+                        max-width var(--transition-speed) var(--transition-timing);
+        }
+
+        body.sidebar-collapsed #content {
+            margin-left: var(--sidebar-collapsed-width);
+            max-width: calc(100% - var(--sidebar-collapsed-width));
+        }
+
+        /* Sidebar Toggle Button */
+        .sidebar-toggle {
+            position: fixed;
+            top: 20px;
+            left: 20px;
+            background: transparent;
+            border: none;
+            border-radius: 6px;
+            padding: 8px;
+            cursor: w-resize;
+            font-size: 18px;
+            color: var(--text-color);
+            transition: left var(--transition-speed) var(--transition-timing),
+                        background 0.2s var(--transition-timing);
+            width: 40px;
+            height: 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 102;
+        }
+
+        .sidebar-toggle:hover,
+        .sidebar-toggle:focus-visible {
+            background: var(--border-color-light);
+            outline: none;
+        }
+
+        body.sidebar-collapsed .sidebar-toggle {
+            left: 4px;
+            cursor: e-resize;
+        }
+        {% else %}
+        /* Single-file layout */
+        body {
+            max-width: var(--content-max-width);
+            margin: 0 auto;
+            padding: 20px;
+        }
+        {% endif %}
+
         .theme-toggle {
-            position: absolute;
+            position: fixed;
             top: 20px;
             right: 20px;
             background: var(--code-bg);
@@ -106,11 +275,15 @@
             cursor: pointer;
             font-size: 14px;
             color: var(--text-color);
-            transition: all 0.3s ease;
+            transition: background 0.2s var(--transition-timing),
+                        border-color var(--transition-speed) var(--transition-timing);
+            z-index: 100;
         }
 
-        .theme-toggle:hover {
+        .theme-toggle:hover,
+        .theme-toggle:focus-visible {
             background: var(--border-color-light);
+            outline: none;
         }
 
         .theme-modal {
@@ -324,6 +497,20 @@
             });
         }
 
+        // Sidebar toggle management
+        function toggleSidebar() {
+            document.body.classList.toggle('sidebar-collapsed');
+            const isCollapsed = document.body.classList.contains('sidebar-collapsed');
+            localStorage.setItem('sidebar-collapsed', isCollapsed ? 'true' : 'false');
+        }
+
+        function initSidebar() {
+            const isCollapsed = localStorage.getItem('sidebar-collapsed') === 'true';
+            if (isCollapsed) {
+                document.body.classList.add('sidebar-collapsed');
+            }
+        }
+
         // Mermaid theme management
         function getMermaidTheme() {
             const currentTheme = document.documentElement.getAttribute('data-theme');
@@ -450,6 +637,7 @@
         // Initialize theme and live reload on page load
         document.addEventListener('DOMContentLoaded', function() {
             initTheme();
+            initSidebar();
             initMermaid();
             setupLiveReload();
 
@@ -473,6 +661,29 @@
     </script>
 </head>
 <body>
+{% if show_navigation %}
+<button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle sidebar">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+        <line x1="9" y1="3" x2="9" y2="21"></line>
+    </svg>
+</button>
+<nav class="sidebar">
+    <div class="sidebar-header"></div>
+    <div class="sidebar-content">
+        <ul class="file-list">
+            {% for file in files %}
+            <li>
+                <a href="/{{ file.name }}"{% if file.name == current_file %} class="active"{% endif %}>
+                    {{ file.name }}
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</nav>
+{% endif %}
+
 <button class="theme-toggle" onclick="openThemeModal()">🎨</button>
 <div id="content">
 {{ content }}


### PR DESCRIPTION
Serve entire directories of markdown files with navigation sidebar and live reload. Single-file mode unchanged for backwards compatibility.

Directory mode tracks all .md files in immediate directory (non-recursive), shows sidebar with active file highlighting, and triggers live reload on create/modify/delete/rename operations.

Unified architecture: both modes share same code path, differ only in UI presentation. Pre-rendered HTML cached in memory for fast serving. See docs/architecture.md for details.

Breaking change: Removed /raw endpoint (incompatible with multi-file mode).

Closes: https://github.com/jfernandez/mdserve/issues/26