### PR TITLE
feat: add YAML and TOML frontmatter support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -175,6 +175,7 @@ impl MarkdownState {
     fn markdown_to_html(content: &str) -> Result<String> {
         let mut options = markdown::Options::gfm();
         options.compile.allow_dangerous_html = true;
+        options.parse.constructs.frontmatter = true;
 
         let html_body = markdown::to_html_with_options(content, &options)
             .unwrap_or_else(|_| "Error parsing markdown".to_string());


### PR DESCRIPTION
Enable frontmatter parsing in markdown-rs by setting the frontmatter construct flag. This strips YAML (---) and TOML (+++) metadata blocks from rendered output.

The markdown-rs library provides built-in frontmatter support that just needed to be enabled via options.parse.constructs.frontmatter.

Closes: https://github.com/jfernandez/mdserve/issues/32