### PR TITLE
Fix for math, escape backslashes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,10 +92,16 @@ struct MarkdownState {
     tracked_files: HashMap<String, TrackedFile>,
     is_directory_mode: bool,
     change_tx: broadcast::Sender<ServerMessage>,
+    math: bool,
 }
 
 impl MarkdownState {
-    fn new(base_dir: PathBuf, file_paths: Vec<PathBuf>, is_directory_mode: bool) -> Result<Self> {
+    fn new(
+        base_dir: PathBuf,
+        file_paths: Vec<PathBuf>,
+        is_directory_mode: bool,
+        math: bool,
+    ) -> Result<Self> {
         let (change_tx, _) = broadcast::channel::<ServerMessage>(16);
 
         let mut tracked_files = HashMap::new();
@@ -103,7 +109,7 @@ impl MarkdownState {
             let metadata = fs::metadata(&file_path)?;
             let last_modified = metadata.modified()?;
             let content = fs::read_to_string(&file_path)?;
-            let html = Self::markdown_to_html(&content)?;
+            let html = Self::markdown_to_html(&content, math)?;
 
             let filename = file_path.file_name().unwrap().to_string_lossy().to_string();
 
@@ -122,6 +128,7 @@ impl MarkdownState {
             tracked_files,
             is_directory_mode,
             change_tx,
+            math,
         })
     }
 
@@ -135,14 +142,14 @@ impl MarkdownState {
         filenames
     }
 
-    fn refresh_file(&mut self, filename: &str) -> Result<()> {
+    fn refresh_file(&mut self, filename: &str, math: bool) -> Result<()> {
         if let Some(tracked) = self.tracked_files.get_mut(filename) {
             let metadata = fs::metadata(&tracked.path)?;
             let current_modified = metadata.modified()?;
 
             if current_modified > tracked.last_modified {
                 let content = fs::read_to_string(&tracked.path)?;
-                tracked.html = Self::markdown_to_html(&content)?;
+                tracked.html = Self::markdown_to_html(&content, math)?;
                 tracked.last_modified = current_modified;
             }
         }
@@ -150,7 +157,7 @@ impl MarkdownState {
         Ok(())
     }
 
-    fn add_tracked_file(&mut self, file_path: PathBuf) -> Result<()> {
+    fn add_tracked_file(&mut self, file_path: PathBuf, math: bool) -> Result<()> {
         let filename = file_path.file_name().unwrap().to_string_lossy().to_string();
 
         if self.tracked_files.contains_key(&filename) {
@@ -165,19 +172,21 @@ impl MarkdownState {
             TrackedFile {
                 path: file_path,
                 last_modified: metadata.modified()?,
-                html: Self::markdown_to_html(&content)?,
+                html: Self::markdown_to_html(&content, math)?,
             },
         );
 
         Ok(())
     }
 
-    fn markdown_to_html(content: &str) -> Result<String> {
+    fn markdown_to_html(content: &str, math: bool) -> Result<String> {
         let mut options = markdown::Options::gfm();
         options.compile.allow_dangerous_html = true;
         options.parse.constructs.frontmatter = true;
-        options.parse.constructs.math_text = true;
-        options.parse.constructs.math_flow = true;
+        if math {
+            options.parse.constructs.math_text = true;
+            options.parse.constructs.math_flow = true;
+        }
 
         let html_body = markdown::to_html_with_options(content, &options)
             .unwrap_or_else(|_| "Error parsing markdown".to_string());
@@ -199,15 +208,19 @@ async fn handle_markdown_file_change(path: &Path, state: &SharedMarkdownState) {
     };
 
     let mut state_guard = state.lock().await;
+    let math = state_guard.math;
 
     // If file is already tracked, refresh its content
     if state_guard.tracked_files.contains_key(&filename) {
-        if state_guard.refresh_file(&filename).is_ok() {
+        if state_guard.refresh_file(&filename, math).is_ok() {
             let _ = state_guard.change_tx.send(ServerMessage::Reload);
         }
     } else if state_guard.is_directory_mode {
         // New file in directory mode - add and reload
-        if state_guard.add_tracked_file(path.to_path_buf()).is_ok() {
+        if state_guard
+            .add_tracked_file(path.to_path_buf(), math)
+            .is_ok()
+        {
             let _ = state_guard.change_tx.send(ServerMessage::Reload);
         }
     }
@@ -291,6 +304,7 @@ pub fn new_router(
     base_dir: PathBuf,
     tracked_files: Vec<PathBuf>,
     is_directory_mode: bool,
+    math: bool,
 ) -> Result<Router> {
     let base_dir = base_dir.canonicalize()?;
 
@@ -298,6 +312,7 @@ pub fn new_router(
         base_dir.clone(),
         tracked_files,
         is_directory_mode,
+        math,
     )?));
 
     let watcher_state = state.clone();
@@ -347,11 +362,12 @@ pub async fn serve_markdown(
     is_directory_mode: bool,
     hostname: impl AsRef<str>,
     port: u16,
+    math: bool,
 ) -> Result<()> {
     let hostname = hostname.as_ref();
 
     let first_file = tracked_files.first().cloned();
-    let router = new_router(base_dir.clone(), tracked_files, is_directory_mode)?;
+    let router = new_router(base_dir.clone(), tracked_files, is_directory_mode, math)?;
 
     let listener = TcpListener::bind((hostname, port)).await?;
 
@@ -394,7 +410,9 @@ async fn serve_html_root(State(state): State<SharedMarkdownState>) -> impl IntoR
         }
     };
 
-    let _ = state.refresh_file(&filename);
+    let math = state.math;
+
+    let _ = state.refresh_file(&filename, math);
 
     render_markdown(&state, &filename).await
 }
@@ -410,7 +428,8 @@ async fn serve_file(
             return (StatusCode::NOT_FOUND, Html("File not found".to_string())).into_response();
         }
 
-        let _ = state.refresh_file(&filename);
+        let math = state.math;
+        let _ = state.refresh_file(&filename, math);
 
         let (status, html) = render_markdown(&state, &filename).await;
         (status, html).into_response()

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ struct Args {
     /// Port to serve on
     #[arg(short, long, default_value = "3000")]
     port: u16,
+
+    /// Enable parsing of LaTeX math blocks
+    #[arg(short, long, default_value_t = false)]
+    math: bool,
 }
 
 #[tokio::main]
@@ -52,6 +56,7 @@ async fn main() -> Result<()> {
         is_directory_mode,
         args.hostname,
         args.port,
+        args.math,
     )
     .await?;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -32,8 +32,9 @@ fn create_test_server_impl(content: &str, use_http: bool) -> (TestServer, NamedT
     let tracked_files = vec![canonical_path];
     let is_directory_mode = false;
 
-    let router =
-        new_router(base_dir, tracked_files, is_directory_mode).expect("Failed to create router");
+    let math = false;
+    let router = new_router(base_dir, tracked_files, is_directory_mode, math)
+        .expect("Failed to create router");
 
     let server = if use_http {
         TestServer::builder()
@@ -69,8 +70,9 @@ fn create_directory_server_impl(use_http: bool) -> (TestServer, TempDir) {
     let tracked_files = scan_markdown_files(&base_dir).expect("Failed to scan markdown files");
     let is_directory_mode = true;
 
-    let router =
-        new_router(base_dir, tracked_files, is_directory_mode).expect("Failed to create router");
+    let math = false;
+    let router = new_router(base_dir, tracked_files, is_directory_mode, math)
+        .expect("Failed to create router");
 
     let server = if use_http {
         TestServer::builder()
@@ -234,8 +236,9 @@ async fn test_image_serving() {
     let base_dir = temp_dir.path().to_path_buf();
     let tracked_files = vec![md_path];
     let is_directory_mode = false;
-    let router =
-        new_router(base_dir, tracked_files, is_directory_mode).expect("Failed to create router");
+    let math = false;
+    let router = new_router(base_dir, tracked_files, is_directory_mode, math)
+        .expect("Failed to create router");
     let server = TestServer::new(router).expect("Failed to create test server");
 
     // Test that markdown includes img tag
@@ -271,8 +274,9 @@ async fn test_non_image_files_not_served() {
     let base_dir = temp_dir.path().to_path_buf();
     let tracked_files = vec![md_path];
     let is_directory_mode = false;
-    let router =
-        new_router(base_dir, tracked_files, is_directory_mode).expect("Failed to create router");
+    let math = false;
+    let router = new_router(base_dir, tracked_files, is_directory_mode, math)
+        .expect("Failed to create router");
     let server = TestServer::new(router).expect("Failed to create test server");
 
     // Test that non-image files return 404


### PR DESCRIPTION
Although #48 was capable of rendering math formulas, newlines (`\\`) are being escaped, resulting in a single backslash (`\`).

This PR enables the math options, so backslashes are not being escaped inside math environments.

Looks a bit weird as `markdown-rs` uses `code` element and therefore, its styles. Though can be fixed by including a new style section with #48.

Edit: Math parsing can be activated with `--math` flag.