### PR TITLE
Allow routing for files on other directories

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -323,7 +323,7 @@ pub fn new_router(
         .route("/", get(serve_html_root))
         .route("/ws", get(websocket_handler))
         .route("/mermaid.min.js", get(serve_mermaid_js))
-        .route("/:filename", get(serve_file))
+        .route("/*filename", get(serve_file))
         .layer(CorsLayer::permissive())
         .with_state(state);
 


### PR DESCRIPTION
Allow accessing files outside the base directory.

Currently for images on other folders, but can also be beneficial for #48 if including some local scripts / css files in the header (needs implementing serving).

---

Original PR was adding an option for image folder:

Allows serving images from other directories than the base directory, e.g., `img/`:
```
mdserve -i img .
```