### PR TITLE
Add canonical flag to hide navigation sidebar in directory mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use std::path::PathBuf;
 
 use mdserve::{scan_markdown_files, serve_markdown};
@@ -19,6 +19,10 @@ struct Args {
     /// Port to serve on
     #[arg(short, long, default_value = "3000")]
     port: u16,
+
+    /// Canonical mode - no navigation shown in sidebar for a directory
+    #[arg(short, long, action = ArgAction::SetTrue)]
+    canonical: bool,
 }
 
 #[tokio::main]
@@ -45,13 +49,14 @@ async fn main() -> Result<()> {
         anyhow::bail!("Path must be a file or directory");
     };
 
-    // Single unified serve function
+    // Pass the canonical flag to control navigation display
     serve_markdown(
         base_dir,
         tracked_files,
         is_directory_mode,
         args.hostname,
         args.port,
+        args.canonical,
     )
     .await?;
 


### PR DESCRIPTION
This addes a `-c` or `--canonical` flag which disables the sidebar when in directory mode. 

The use case in mind, is when you want to serve a directory but only send canonical links to people for ephemeral sharing.

Closes #52