### PR TITLE
refactor: consolidate stray HashMap import

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use minijinja::{context, value::Value, Environment};
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     fs,
     net::Ipv6Addr,
     path::{Path, PathBuf},
@@ -54,8 +55,6 @@ pub enum ServerMessage {
     Reload,
     Pong,
 }
-
-use std::collections::HashMap;
 
 pub fn scan_markdown_files(dir: &Path) -> Result<Vec<PathBuf>> {
     let mut md_files = Vec::new();


### PR DESCRIPTION
## Summary
- Move `use std::collections::HashMap` from line 58 (between struct definitions) into the top-level `use std::{...}` import block where it belongs

## Test plan
- [x] `cargo test` passes (27 tests)
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)