### PR TITLE
feat: add --open flag to launch browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ mdserve docs/ -p 8080
 
 # Serve on custom hostname and port
 mdserve README.md --hostname 0.0.0.0 --port 8080
+
+# Open in browser automatically
+mdserve README.md --open
 ```
 
 ### Single-File vs Directory Mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,10 @@ struct Args {
     /// Port to serve on
     #[arg(short, long, default_value = "3000")]
     port: u16,
+
+    /// Open the preview in the default browser
+    #[arg(short, long)]
+    open: bool,
 }
 
 #[tokio::main]
@@ -54,6 +58,7 @@ async fn main() -> Result<()> {
         is_directory_mode,
         args.hostname,
         args.port,
+        args.open,
     )
     .await?;
 


### PR DESCRIPTION
Spawns xdg-open (Linux) or open (macOS) after the listener binds so the preview is immediately reachable. Wildcard bind addresses like 0.0.0.0 are mapped to loopback for the browser URL. Spawn failure is fatal, but exit status is monitored in a background thread to avoid deadlocking with the server.