### PR TITLE
fix: hide bullet markers on task list checkbox items

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -449,6 +449,14 @@
         a { color: var(--link-color); text-decoration: none; }
         a:hover { text-decoration: underline; }
         img { max-width: 100%; height: auto; }
+
+        /* Task list checkboxes: hide bullet when item has a checkbox */
+        li:has(> input[type="checkbox"]) {
+            list-style: none;
+        }
+        input[type="checkbox"] {
+            margin-inline-end: 0.25em;
+        }
     </style>
 
     {% if mermaid_enabled %}


### PR DESCRIPTION
## Summary

- GFM task list items (`- [ ]`, `- [x]`) render with both a bullet disc and a checkbox, resulting in a cluttered appearance
- Adds CSS using `li:has(> input[type="checkbox"])` to hide the bullet on checkbox items
- Adds a small `margin-inline-end` on checkboxes for spacing between the box and label text

### Before

![before](https://github.com/user-attachments/assets/placeholder-before)

```
• ☐ Plan the project
• ☑ Set up the repository
```

### After

```
☐ Plan the project
☑ Set up the repository
```

### Example markdown

```markdown
- [ ] Plan the project
- [x] Set up the repository
- [ ] Write tests
```

## Test plan

- [ ] Serve a markdown file containing `- [ ]` and `- [x]` task list items
- [ ] Verify checkboxes render without bullet markers
- [ ] Verify regular unordered lists still show bullets
- [ ] Test across light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)