### PR TITLE
feat: add syntax highlighting to code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,7 +111,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -113,7 +122,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -242,6 +251,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,7 +356,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -355,6 +388,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -406,7 +448,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -420,10 +462,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -478,7 +541,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -895,11 +958,13 @@ dependencies = [
  "notify",
  "serde",
  "serde_json",
+ "syntect",
  "tempfile",
  "tokio",
  "tokio-test",
  "tower",
  "tower-http",
+ "two-face",
 ]
 
 [[package]]
@@ -946,6 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1118,6 +1184,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "reserve-port"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1194,22 +1277,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1260,6 +1343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1394,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,7 +1418,25 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.16",
+ "walkdir",
 ]
 
 [[package]]
@@ -1360,7 +1478,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1371,7 +1489,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1441,7 +1559,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1592,6 +1710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,7 +1857,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -1750,7 +1879,7 @@ checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1979,7 +2108,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2000,7 +2129,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2020,7 +2149,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -2054,5 +2183,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = "1.0"
 anyhow = "1.0"
 minijinja = "2.12.0"
 minijinja-embed = { version = "2.12.0", default-features = false }
+syntect = { version = "5.3.0", default-features = false, features = ["html", "regex-fancy"] }
+two-face = { version = "0.5.1", default-features = false, features = ["syntect-fancy"] }
 
 [build-dependencies]
 minijinja-embed = { version = "2.12.0", default-features = false }

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,11 @@ use std::{
     sync::{Arc, OnceLock},
     time::SystemTime,
 };
+use syntect::{
+    html::{ClassStyle, ClassedHTMLGenerator},
+    parsing::{SyntaxReference, SyntaxSet},
+    util::LinesWithEndings,
+};
 use tokio::{
     net::TcpListener,
     sync::{broadcast, mpsc, Mutex},
@@ -32,6 +37,10 @@ static TEMPLATE_ENV: OnceLock<Environment<'static>> = OnceLock::new();
 const MERMAID_JS: &str = include_str!("../static/js/mermaid.min.js");
 const MERMAID_ETAG: &str = concat!("\"", env!("CARGO_PKG_VERSION"), "\"");
 const MAX_PORT_ATTEMPTS: u16 = 10;
+
+/// Prefix keeps syntect's scope classes from colliding with page styles.
+const HL_CLASS_STYLE: ClassStyle = ClassStyle::SpacedPrefixed { prefix: "hl-" };
+static SYNTAX_SET: OnceLock<SyntaxSet> = OnceLock::new();
 
 type SharedMarkdownState = Arc<Mutex<MarkdownState>>;
 
@@ -166,8 +175,142 @@ impl MarkdownState {
         let html_body = markdown::to_html_with_options(content, &options)
             .unwrap_or_else(|_| "Error parsing markdown".to_string());
 
-        Ok(html_body)
+        Ok(highlight_code_blocks(&html_body))
     }
+}
+
+fn syntax_set() -> &'static SyntaxSet {
+    // two-face bundles the Sublime defaults plus the extras bat ships
+    // (TypeScript, TOML, Dockerfile, Kotlin, Swift, Zig, ...), which agents
+    // emit often enough that the default set alone leaves visible gaps.
+    SYNTAX_SET.get_or_init(two_face::syntax::extra_newlines)
+}
+
+/// Applies syntax highlighting to fenced code blocks in already-rendered HTML.
+///
+/// The markdown crate exposes no hook for customizing code block output, so
+/// blocks are rewritten after the fact. Mermaid blocks are left untouched for
+/// the client-side renderer, as are blocks without a recognized language.
+fn highlight_code_blocks(html: &str) -> String {
+    const OPEN: &str = "<pre><code class=\"language-";
+    const ATTR_END: &str = "\">";
+    const CLOSE: &str = "</code></pre>";
+
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+
+    while let Some(open_at) = rest.find(OPEN) {
+        let tail = &rest[open_at + OPEN.len()..];
+        out.push_str(&rest[..open_at + OPEN.len()]);
+
+        // The language comes from the info string, where the markdown crate
+        // has already encoded any quote, so the first `">` ends the attribute.
+        let Some(lang_end) = tail.find(ATTR_END) else {
+            break;
+        };
+        let lang = &tail[..lang_end];
+        let body = &tail[lang_end + ATTR_END.len()..];
+
+        // Code content is entity-encoded, so it cannot contain the closing tag.
+        let Some(code_end) = body.find(CLOSE) else {
+            break;
+        };
+        let code = &body[..code_end];
+
+        out.push_str(lang);
+        out.push_str(ATTR_END);
+        match highlight(lang, code) {
+            Some(highlighted) => out.push_str(&highlighted),
+            None => out.push_str(code),
+        }
+
+        rest = &body[code_end..];
+    }
+
+    out.push_str(rest);
+    out
+}
+
+/// Highlights one entity-encoded code block, or returns `None` to leave it as is.
+fn highlight(lang: &str, encoded_code: &str) -> Option<String> {
+    if lang.eq_ignore_ascii_case("mermaid") {
+        return None;
+    }
+
+    let syntaxes = syntax_set();
+    let syntax = find_syntax(syntaxes, lang)?;
+    let code = decode_html_entities(encoded_code);
+
+    let mut generator =
+        ClassedHTMLGenerator::new_with_class_style(syntax, syntaxes, HL_CLASS_STYLE);
+    for line in LinesWithEndings::from(&code) {
+        generator
+            .parse_html_for_line_which_includes_newline(line)
+            .ok()?;
+    }
+
+    Some(generator.finalize())
+}
+
+fn find_syntax<'a>(syntaxes: &'a SyntaxSet, lang: &str) -> Option<&'a SyntaxReference> {
+    let lower = lang.to_ascii_lowercase();
+
+    syntaxes
+        .find_syntax_by_token(lang)
+        .or_else(|| syntaxes.find_syntax_by_token(&lower))
+        .or_else(|| syntax_alias(&lower).and_then(|token| syntaxes.find_syntax_by_token(token)))
+        .filter(|syntax| syntax.name != "Plain Text")
+}
+
+/// Maps fence labels that syntect does not resolve on its own.
+fn syntax_alias(lang: &str) -> Option<&'static str> {
+    Some(match lang {
+        "shell" | "shellscript" | "shell-session" | "console" => "sh",
+        "golang" => "go",
+        "c++" => "cpp",
+        "c#" | "csharp" => "cs",
+        "objective-c" | "objectivec" => "m",
+        "yml" => "yaml",
+        "jsonc" | "json5" => "json",
+        "kt" => "kotlin",
+        "terraform" => "tf",
+        "make" => "makefile",
+        "patch" => "diff",
+        "vue" | "svelte" => "html",
+        _ => return None,
+    })
+}
+
+/// Reverses the entity encoding the markdown crate applies to code content.
+fn decode_html_entities(input: &str) -> String {
+    const ENTITIES: [(&str, char); 4] = [
+        ("&amp;", '&'),
+        ("&lt;", '<'),
+        ("&gt;", '>'),
+        ("&quot;", '"'),
+    ];
+
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+
+    while let Some(amp_at) = rest.find('&') {
+        out.push_str(&rest[..amp_at]);
+        rest = &rest[amp_at..];
+
+        match ENTITIES.iter().find(|(entity, _)| rest.starts_with(entity)) {
+            Some((entity, decoded)) => {
+                out.push(*decoded);
+                rest = &rest[entity.len()..];
+            }
+            None => {
+                out.push('&');
+                rest = &rest['&'.len_utf8()..];
+            }
+        }
+    }
+
+    out.push_str(rest);
+    out
 }
 
 /// Handles a markdown file that may have been created or modified.
@@ -758,6 +901,110 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_html_entities() {
+        assert_eq!(decode_html_entities("plain text"), "plain text");
+        assert_eq!(
+            decode_html_entities("a &lt; b &amp;&amp; c &gt; d"),
+            "a < b && c > d"
+        );
+        assert_eq!(decode_html_entities("&quot;quoted&quot;"), "\"quoted\"");
+
+        // A literal ampersand survives, and encoded entities are not
+        // double-decoded into markup
+        assert_eq!(decode_html_entities("R&D"), "R&D");
+        assert_eq!(decode_html_entities("&amp;lt;"), "&lt;");
+    }
+
+    #[test]
+    fn test_syntax_alias_resolves_unknown_tokens() {
+        let syntaxes = syntax_set();
+
+        for lang in ["rust", "rs", "python", "js", "typescript", "toml", "yaml"] {
+            assert!(
+                find_syntax(syntaxes, lang).is_some(),
+                "expected a syntax for {lang}"
+            );
+        }
+
+        assert_eq!(
+            find_syntax(syntaxes, "shell").map(|s| s.name.as_str()),
+            find_syntax(syntaxes, "sh").map(|s| s.name.as_str())
+        );
+        assert_eq!(
+            find_syntax(syntaxes, "golang").map(|s| s.name.as_str()),
+            find_syntax(syntaxes, "go").map(|s| s.name.as_str())
+        );
+
+        assert!(find_syntax(syntaxes, "text").is_none());
+        assert!(find_syntax(syntaxes, "not-a-language").is_none());
+    }
+
+    #[test]
+    fn test_highlight_code_blocks_wraps_tokens_in_scope_classes() {
+        let html = MarkdownState::markdown_to_html("```rust\nlet x = 1;\n```\n")
+            .expect("Failed to render markdown");
+
+        assert!(html.starts_with(r#"<pre><code class="language-rust"><span class="hl-"#));
+        assert!(html.contains(r#"<span class="hl-storage hl-type hl-rust">let</span>"#));
+        assert!(html.contains(
+            r#"<span class="hl-constant hl-numeric hl-integer hl-decimal hl-rust">1</span>"#
+        ));
+        assert!(html.trim_end().ends_with("</code></pre>"));
+    }
+
+    #[test]
+    fn test_highlight_code_blocks_preserves_entity_encoding() {
+        let html = MarkdownState::markdown_to_html("```rust\nlet s = \"a & b <c>\";\n```\n")
+            .expect("Failed to render markdown");
+
+        // Characters that were encoded before highlighting must stay encoded
+        assert!(html.contains("a &amp; b &lt;c&gt;"));
+        assert!(!html.contains("a & b <c>"));
+    }
+
+    #[test]
+    fn test_highlight_code_blocks_leaves_untouched_blocks_alone() {
+        let mermaid = MarkdownState::markdown_to_html("```mermaid\ngraph TD\n  A --> B\n```\n")
+            .expect("Failed to render markdown");
+        assert_eq!(
+            mermaid.trim_end(),
+            "<pre><code class=\"language-mermaid\">graph TD\n  A --&gt; B\n</code></pre>"
+        );
+
+        let unknown = MarkdownState::markdown_to_html("```not-a-language\nx = 1\n```\n")
+            .expect("Failed to render markdown");
+        assert_eq!(
+            unknown.trim_end(),
+            "<pre><code class=\"language-not-a-language\">x = 1\n</code></pre>"
+        );
+
+        let no_lang = MarkdownState::markdown_to_html("```\nx = 1\n```\n")
+            .expect("Failed to render markdown");
+        assert_eq!(no_lang.trim_end(), "<pre><code>x = 1\n</code></pre>");
+    }
+
+    #[test]
+    fn test_highlight_code_blocks_handles_multiple_blocks() {
+        let html = MarkdownState::markdown_to_html(
+            "```rust\nlet x = 1;\n```\n\ntext\n\n```python\nx = 1\n```\n",
+        )
+        .expect("Failed to render markdown");
+
+        assert!(html.contains(r#"<pre><code class="language-rust"><span class="hl-"#));
+        assert!(html.contains(r#"<pre><code class="language-python"><span class="hl-"#));
+        assert!(html.contains("<p>text</p>"));
+        assert_eq!(html.matches("</code></pre>").count(), 2);
+    }
+
+    #[test]
+    fn test_inline_code_is_not_highlighted() {
+        let html = MarkdownState::markdown_to_html("Use `let x = 1;` here.\n")
+            .expect("Failed to render markdown");
+
+        assert_eq!(html.trim_end(), "<p>Use <code>let x = 1;</code> here.</p>");
+    }
+
+    #[test]
     fn test_scan_markdown_files_empty_directory() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
 
@@ -1028,7 +1275,9 @@ fn main() {
         assert!(body.contains("<td>John</td>"));
         assert!(body.contains("<del>deleted text</del>"));
         assert!(body.contains("<pre>"));
-        assert!(body.contains("fn main()"));
+        // Code is split across highlight spans, so match on the tokens
+        assert!(body.contains(r#"<span class="hl-storage hl-type hl-function hl-rust">fn</span>"#));
+        assert!(body.contains(r#"<span class="hl-entity hl-name hl-function hl-rust">main</span>"#));
     }
 
     #[tokio::test]
@@ -1156,8 +1405,9 @@ console.log("Hello World");
         assert_eq!(response.status_code(), 200);
         let body = response.text();
 
-        assert!(body.contains(r#"class="language-mermaid""#));
-        assert!(body.contains("graph TD"));
+        // Mermaid blocks stay unhighlighted so the client-side renderer can
+        // read their textContent verbatim
+        assert!(body.contains(r#"<pre><code class="language-mermaid">graph TD"#));
 
         let has_raw_content = body.contains("A[Start] --> B{Decision}");
         let has_encoded_content = body.contains("A[Start] --&gt; B{Decision}");
@@ -1170,8 +1420,7 @@ console.log("Hello World");
         assert!(body.contains("function initMermaid()"));
         assert!(body.contains("function transformMermaidCodeBlocks()"));
         assert!(body.contains("function getMermaidTheme()"));
-        assert!(body.contains(r#"class="language-javascript""#));
-        assert!(body.contains("console.log"));
+        assert!(body.contains(r#"<pre><code class="language-javascript"><span class="hl-"#));
     }
 
     #[tokio::test]

--- a/templates/main.html
+++ b/templates/main.html
@@ -62,6 +62,15 @@
             --content-max-width: 900px;
             --transition-speed: 0.3s;
             --transition-timing: ease;
+
+            /* Syntax highlighting (GitHub Light) */
+            --hl-comment: #6a737d;
+            --hl-keyword: #d73a49;
+            --hl-string: #032f62;
+            --hl-constant: #005cc5;
+            --hl-entity: #6f42c1;
+            --hl-support: #005cc5;
+            --hl-invalid: #b31d28;
         }
 
         [data-theme="dark"] {
@@ -73,6 +82,15 @@
             --blockquote-color: #8b949e;
             --link-color: #58a6ff;
             --table-header-bg: #161b22;
+
+            /* GitHub Dark */
+            --hl-comment: #8b949e;
+            --hl-keyword: #ff7b72;
+            --hl-string: #a5d6ff;
+            --hl-constant: #79c0ff;
+            --hl-entity: #d2a8ff;
+            --hl-support: #79c0ff;
+            --hl-invalid: #ffa198;
         }
 
         [data-theme="catppuccin-latte"] {
@@ -84,6 +102,14 @@
             --blockquote-color: #6c6f85;
             --link-color: #1e66f5;
             --table-header-bg: #ccd0da;
+
+            --hl-comment: #7c7f93;
+            --hl-keyword: #8839ef;
+            --hl-string: #40a02b;
+            --hl-constant: #fe640b;
+            --hl-entity: #1e66f5;
+            --hl-support: #179299;
+            --hl-invalid: #d20f39;
         }
 
         [data-theme="catppuccin-macchiato"] {
@@ -95,6 +121,14 @@
             --blockquote-color: #a5adcb;
             --link-color: #8aadf4;
             --table-header-bg: #363a4f;
+
+            --hl-comment: #939ab7;
+            --hl-keyword: #c6a0f6;
+            --hl-string: #a6da95;
+            --hl-constant: #f5a97f;
+            --hl-entity: #8aadf4;
+            --hl-support: #8bd5ca;
+            --hl-invalid: #ed8796;
         }
 
         [data-theme="catppuccin-mocha"] {
@@ -106,6 +140,14 @@
             --blockquote-color: #a6adc8;
             --link-color: #89b4fa;
             --table-header-bg: #313244;
+
+            --hl-comment: #9399b2;
+            --hl-keyword: #cba6f7;
+            --hl-string: #a6e3a1;
+            --hl-constant: #fab387;
+            --hl-entity: #89b4fa;
+            --hl-support: #94e2d5;
+            --hl-invalid: #f38ba8;
         }
 
         /* Common body styles */
@@ -418,6 +460,22 @@
             background-color: transparent;
             padding: 0;
         }
+
+        /* Syntax highlighting. Classes come from syntect scope atoms, so a span
+           may carry several of these at once (e.g. punctuation.definition.string
+           matches both .hl-punctuation and .hl-string). Rules are ordered from
+           least to most specific meaning, letting the later rule win the tie. */
+        .hl-entity { color: var(--hl-entity); }
+        .hl-support { color: var(--hl-support); }
+        .hl-constant { color: var(--hl-constant); }
+        .hl-keyword,
+        .hl-storage { color: var(--hl-keyword); }
+        .hl-string { color: var(--hl-string); }
+        .hl-comment {
+            color: var(--hl-comment);
+            font-style: italic;
+        }
+        .hl-invalid { color: var(--hl-invalid); }
         blockquote {
             border-left: 4px solid var(--border-color-light);
             padding-left: 16px;


### PR DESCRIPTION
Closes #24.

Fenced code blocks are highlighted server-side with syntect. Output is class-based, so one pre-rendered copy of the HTML serves all five themes and theme switching stays client-side.

**Approach**
- syntect emits `hl-`-prefixed scope classes instead of inline styles. Token colors are CSS vars (`--hl-keyword`, `--hl-string`, ...) redefined per `data-theme` - GitHub light/dark palettes for those two themes, Catppuccin palettes for the other three.
- The markdown crate exposes no code-block hook, so `highlight_code_blocks` rewrites `<pre><code class="language-*">` in the generated HTML.
- Mermaid blocks are skipped; the client renderer reads their textContent verbatim. Unknown and no-language blocks pass through untouched.
- Syntax set comes from two-face rather than syntect's defaults, which lack TypeScript, TOML, and Dockerfile. A small alias table covers fence labels syntect won't resolve (`shell`, `golang`, `c++`, `yml`, `kt`).

**Cost**
- Binary: 5.1MB → 7.3MB release.
- Startup: one-time ~200ms SyntaxSet deserialize on the first file containing a code block (56ms → 264ms to first response). Cached after that.
- Both deps are pure Rust (`regex-fancy`, no oniguruma), so no C toolchain - the single-binary holds.

**Tests**
44 pass, clippy `-D warnings` clean, fmt clean. 7 new tests cover entity
decode/re-encode, alias resolution, scope classes, and the three skip cases.